### PR TITLE
Add parameters on autocmd section

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,8 +39,12 @@
 #     Valid values are either 'dark' or 'light'.
 #     Default: dark
 #
+#   [*opt_indent*]
+#     If true, Vim loads indentation rules and plugins according to the detected filetype.
+#     Default: true
+#
 #   [*opt_lastposition*]
-#     If true Vim jumps to the last known position when reopening a file.
+#     If true, Vim jumps to the last known position when reopening a file.
 #     Default: true
 #
 #   [*opt_powersave*]
@@ -74,6 +78,7 @@ class vim(
   $test_editor_set  = $vim::params::test_editor_set,
   $conf_file        = $vim::params::conf,
   $opt_bg_shading   = $vim::params::background,
+  $opt_indent       = $vim::params::indent,
   $opt_lastposition = $vim::params::lastposition,
   $opt_powersave    = $vim::params::powersave,
   $opt_syntax       = $vim::params::syntax,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,7 @@
 class vim::params {
   $background   = 'dark'
   $lastposition = true
+  $indent       = true
   $powersave    = true
   $syntax       = true
   $misc         = ['hlsearch','showcmd','showmatch','ignorecase','smartcase','incsearch','autowrite','hidden']

--- a/templates/vimrc.erb
+++ b/templates/vimrc.erb
@@ -12,8 +12,8 @@ endif
 if has("autocmd")
 <% if @opt_lastposition %>  au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g'\"" | endif
 <% end %>  autocmd BufNewFile,BufReadPre /media/*,/mnt/* set directory=~/tmp,/var/tmp,/tmp
-  filetype plugin indent on
-endif
+<% if @opt_indent %>  filetype plugin indent on
+<% end %>endif
 
 <% @opt_misc.each do |option| -%>
 set <%= option %>


### PR DESCRIPTION
Add two params to make these behaviours optional :
- Vim loads indentation rules and plugins according to the detected filetype ;
- Vim jumps to the last known position when reopening a file.
