### PR TITLE
add missing conf variable for FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,7 @@ class vim::params {
       $set_as_default  = false
       $set_editor_cmd  = undef
       $test_editor_set = undef
+      $conf            = '/usr/local/etc/vim/vimrc'
     }
     'Suse': {
       $package         = 'vim'


### PR DESCRIPTION
`$conf` was missing from FreeBSD parameters, so this adds it.

Before you got `Evaluation Error: Missing title. The title expression resulted in undef` because of this.