### PR TITLE
freebsd renamed vim-lite to vim-console

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class vim::params {
       $conf            = '/etc/vimrc'
     }
     'FreeBSD': {
-      $package         = 'vim-lite'
+      $package         = 'vim-console'
       $set_as_default  = false
       $set_editor_cmd  = undef
       $test_editor_set = undef


### PR DESCRIPTION
FreeBSD has renamed `vim-lite` to `vim-console` as can be read in `/usr/ports/UPDATING`:

```
20180111:
  AFFECTS: users of editors/vim-lite
  AUTHOR: adamw@FreeBSD.org

  The vim-lite port has been renamed to vim-console, because it isn't
  actually any lighter. All three vim packages are built with
  --enable-features=huge. Portmaster users will need to run this
  command:

        portmaster -o editors/vim-console editors/vim-lite

  If the switch doesn't happen automatically for you, just delete the
  vim-lite package and install vim-console.
```