### PR TITLE
Add dependency of the conf file to the package

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,6 +137,7 @@ class vim(
   file { $conf_file:
     ensure  => $file_ensure,
     content => template('vim/vimrc.erb'),
+    require => Package[$package],
   }
 
   if $set_as_default and $set_editor_cmd {


### PR DESCRIPTION
Fix this error:

`Error: Could not set 'file' on ensure: No such file or directory - A directory component in /etc/vim/vimrc20211108-4240-1mz1d2a.lock does not exist or is a dangling symbolic link (file: /etc/puppetlabs/code/environments/production/modules/vim/manifests/init.pp, line: 135)`
